### PR TITLE
chore: pin react to 17 to meet fluentUi req

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "azure-devops-extension-api": "^1.158.0",
         "azure-devops-extension-sdk": "^2.0.11",
         "azure-devops-ui": "^2.167.1",
-        "react": "^18.2.0",
+        "react": "~17",
         "react-progressbar": "^15.4.1"
       },
       "devDependencies": {
@@ -752,18 +752,6 @@
         "react": ">=16.8.0 <18.0.0"
       }
     },
-    "node_modules/@fluentui/font-icons-mdl2/node_modules/react": {
-      "version": "17.0.2",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/@fluentui/keyboard-key": {
       "version": "0.4.1",
       "license": "MIT",
@@ -946,18 +934,6 @@
       "peerDependencies": {
         "@types/react": ">=16.8.0 <18.0.0",
         "react": ">=16.8.0 <18.0.0"
-      }
-    },
-    "node_modules/@fluentui/style-utilities/node_modules/react": {
-      "version": "17.0.2",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/@gar/promisify": {
@@ -9851,10 +9827,12 @@
       }
     },
     "node_modules/react": {
-      "version": "18.2.0",
-      "license": "MIT",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
       "dependencies": {
-        "loose-envify": "^1.1.0"
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -13862,14 +13840,6 @@
             "@fluentui/set-version": "^8.2.1",
             "tslib": "^2.1.0"
           }
-        },
-        "react": {
-          "version": "17.0.2",
-          "peer": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
         }
       }
     },
@@ -14001,14 +13971,6 @@
             "@fluentui/merge-styles": "^8.5.2",
             "@fluentui/set-version": "^8.2.1",
             "tslib": "^2.1.0"
-          }
-        },
-        "react": {
-          "version": "17.0.2",
-          "peer": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
           }
         }
       }
@@ -20297,9 +20259,12 @@
       }
     },
     "react": {
-      "version": "18.2.0",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
       "requires": {
-        "loose-envify": "^1.1.0"
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
       }
     },
     "react-dom": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "azure-devops-extension-api": "^1.158.0",
     "azure-devops-extension-sdk": "^2.0.11",
     "azure-devops-ui": "^2.167.1",
-    "react": "^18.2.0",
+    "react": "~17",
     "react-progressbar": "^15.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
`npm install` was giving me peer dependency errors around fluentUi and react. pinning react to 17 makes them warnings instead (I am using node 16.0).
However, I didn't publish/test this change. 
`npm run test` yields 1 failure, but it appears to also be failing in the target branch  (sara-sabr:main).
`npm install --legacy-peer-deps` also works, I think. So an alternative to this PR might be to change the docs at `npm install` and updating package-lock using --legacy-peer-deps.